### PR TITLE
reactions added to and embedded with posts

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -6,3 +6,4 @@ from .tag import Tag
 from .posttag import PostTag
 from .reaction import REACTION
 from .login import Login
+from .postreaction import PostReaction

--- a/models/post.py
+++ b/models/post.py
@@ -8,4 +8,5 @@ class POST():
         self.image_url = image_url
         self.content = content
         self.tags = []
+        self.reactions = []
         self.approved = approved

--- a/models/postreaction.py
+++ b/models/postreaction.py
@@ -1,0 +1,6 @@
+class PostReaction():
+    def __init__(self, id, user_id, reaction_id, post_id):
+        self.id = id
+        self.user_id = user_id
+        self.reaction_id = reaction_id
+        self.post_id = post_id

--- a/posts/request.py
+++ b/posts/request.py
@@ -3,6 +3,221 @@ import sqlite3
 import json
 from models import POST
 
+
+def create_post(new_post):
+    with sqlite3.connect("./rare.db") as conn:
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        INSERT INTO Posts
+            (user_id, category_id, title, publication_date,
+             image_url, content, approved)
+        VALUES
+            (?, ?, ?, ?, ?, ?, ?);
+        """, (new_post['user_id'], new_post['category_id'], new_post['title'], new_post['publication_date'],
+              new_post['image_url'], new_post['content'], new_post['approved'], ))
+
+        id = db_cursor.lastrowid
+
+        new_post['id'] = id
+
+        for tag_id in new_post['tags']:
+            db_cursor.execute("""
+            INSERT INTO PostTags
+                (post_id, tag_id)
+            VALUES (?,?)
+            """, (new_post['id'], tag_id, ))
+
+    return json.dumps(new_post)
+
+
+def update_post(id, new_post):
+    with sqlite3.connect("./rare.db") as conn:
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        UPDATE Posts
+            SET
+                user_id = ?,
+                category_id = ?,
+                title =?,
+                publication_date = ?,
+                image_url = ?,
+                content = ?,
+                approved = ?
+            WHERE id = ?
+        """, (new_post['user_id'], new_post['category_id'], new_post['title'], new_post['publication_date'],
+              new_post['image_url'], new_post['content'], new_post['approved'], id, ))
+
+            
+        for tag_id in new_post['tags']:
+            db_cursor.execute("""
+            INSERT INTO PostTags
+                (post_id, tag_id)
+            VALUES (?,?)
+            """, (new_post['id'], tag_id, ))
+
+        rows_affected = db_cursor.rowcount
+
+    if rows_affected == 0:
+        return False
+    else:
+        return True
+
+
+def delete_post(id):
+    with sqlite3.connect("./rare.db") as conn:
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        DELETE FROM Posts
+        WHERE id = ?
+        """, (id, ))
+
+
+def get_all_posts():
+    with sqlite3.connect("./rare.db") as conn:
+
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        SELECT
+            p.id,
+            p.user_id,
+            p.category_id,
+            p.title,
+            p.publication_date,
+            p.image_url,
+            p.content,
+            p.approved
+        FROM Posts p
+        """)
+
+        posts = []
+
+        dataset = db_cursor.fetchall()
+
+        for row in dataset:
+            post = POST(row['id'], row['user_id'], row['category_id'], row['title'],
+                        row['publication_date'], row['image_url'], row['content'], row['approved'])
+
+            db_cursor.execute("""
+                SELECT
+                    t.id,
+                    t.label
+                FROM Tags t
+                JOIN PostTags pt
+                    on t.id = pt.tag_id
+                JOIN Posts p on pt.post_id = p.id
+                WHERE p.id = ?
+                """, (post.id, ))
+
+            tag_rows = db_cursor.fetchall()
+
+            for tag_row in tag_rows:
+                tag = {
+                    'id': tag_row['id'],
+                    'label': tag_row['label']
+                }
+                post.tags.append(tag)
+
+            db_cursor.execute("""
+                SELECT
+                    r.id,
+                    r.label,
+                    r.image_url
+                FROM Reactions r
+                JOIN PostReactions pr
+                    on r.id = pr.reaction_id
+                JOIN Posts p on pr.post_id = p.id
+                WHERE p.id = ?
+                """, (post.id, ))
+
+            reaction_rows = db_cursor.fetchall()
+
+            for reaction_row in reaction_rows:
+                reaction = {
+                    'id': reaction_row['id'],
+                    'label': reaction_row['label'],
+                    'image_url': reaction_row['image_url']
+                }
+                post.reactions.append(reaction)
+
+            posts.append(post.__dict__)
+
+        return json.dumps(posts)
+
+
+def get_single_post(id):
+    with sqlite3.connect("./rare.db") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        SELECT
+            p.id,
+            p.user_id,
+            p.category_id,
+            p.title,
+            p.publication_date,
+            p.image_url,
+            p.content,
+            p.approved
+        FROM Posts p
+        WHERE p.id = ?
+        """, (id, ))
+
+        data = db_cursor.fetchone()
+
+        post = POST(data['id'], data['user_id'], data['category_id'], data['title'],
+                    data['publication_date'], data['image_url'], data['content'], data['approved'])
+
+        db_cursor.execute("""
+        SELECT
+            t.id,
+            t.label
+        FROM Tags t
+        JOIN PostTags pt
+            on t.id = pt.tag_id
+        JOIN Posts p on pt.post_id = p.id
+        WHERE p.id = ?
+        """, (post.id, ))
+
+        tag_rows = db_cursor.fetchall()
+
+        for tag_row in tag_rows:
+            tag = {
+                'id': tag_row['id'],
+                'label': tag_row['label']
+            }
+            post.tags.append(tag)
+
+        db_cursor.execute("""
+        SELECT
+            r.id,
+            r.label,
+            r.image_url
+        FROM Reactions r
+        JOIN PostReactions pr
+            on r.id = pr.reaction_id
+        JOIN Posts p on pr.post_id = p.id
+        WHERE p.id = ?
+        """, (post.id, ))
+
+        reaction_rows = db_cursor.fetchall()
+
+        for reaction_row in reaction_rows:
+            reaction = {
+                'id': reaction_row['id'],
+                'label': reaction_row['label'],
+                'image_url': reaction_row['image_url']
+            }
+            post.reactions.append(reaction)
+
+    return json.dumps(post.__dict__)
+
+
 def get_posts_by_subscription(id):
     with sqlite3.connect("./rare.db") as conn:
         conn.row_factory = sqlite3.Row
@@ -23,16 +238,18 @@ def get_posts_by_subscription(id):
         dataset = db_cursor.fetchall()
 
         for row in dataset:
-                post = POST(row['id'], row['user_id'], row['category_id'], row['title'], row['publication_date'], row['image_url'],row['content'], row['approved'])
-                original_posts.append(post.__dict__)
+            post = POST(row['id'], row['user_id'], row['category_id'], row['title'],
+                        row['publication_date'], row['image_url'], row['content'], row['approved'])
+            original_posts.append(post.__dict__)
 
-                posts = []
+            posts = []
 
         for i in original_posts:
             if i not in posts:
                 posts.append(i)
 
     return json.dumps(posts)
+
 
 def get_posts_by_category(category_id):
     with sqlite3.connect("./rare.db") as conn:
@@ -58,9 +275,11 @@ def get_posts_by_category(category_id):
         dataset = db_cursor.fetchall()
 
         for row in dataset:
-                post = POST(row['id'], row['user_id'], row['category_id'], row['title'], row['publication_date'], row['image_url'],row['content'], row['approved'])
-                posts.append(post.__dict__)
+            post = POST(row['id'], row['user_id'], row['category_id'], row['title'],
+                        row['publication_date'], row['image_url'], row['content'], row['approved'])
+            posts.append(post.__dict__)
     return json.dumps(posts)
+
 
 def get_posts_by_user(user_id):
     with sqlite3.connect("./rare.db") as conn:
@@ -86,10 +305,11 @@ def get_posts_by_user(user_id):
         dataset = db_cursor.fetchall()
 
         for row in dataset:
-                post = POST(row['id'], row['user_id'], row['category_id'], row['title'], row['publication_date'], row['image_url'],row['content'], row['approved'])
-                posts.append(post.__dict__)
-                
-                
+            post = POST(row['id'], row['user_id'], row['category_id'], row['title'],
+                        row['publication_date'], row['image_url'], row['content'], row['approved'])
+            posts.append(post.__dict__)
+
+
 def get_posts_by_tag(tag_id):
     with sqlite3.connect("./rare.db") as conn:
         conn.row_factory = sqlite3.Row
@@ -123,165 +343,10 @@ def get_posts_by_tag(tag_id):
         dataset = db_cursor.fetchall()
 
         for row in dataset:
-                post = POST(row['id'], row['user_id'], row['category_id'], row['title'], row['publication_date'], row['image_url'],row['content'], row['approved'])
-                
-                posts.append(post.__dict__)
-                
+            post = POST(row['id'], row['user_id'], row['category_id'], row['title'],
+                        row['publication_date'], row['image_url'], row['content'], row['approved'])
+
+            posts.append(post.__dict__)
+
     return json.dumps(posts)
-
-def update_post(id, new_post):
-    with sqlite3.connect("./rare.db") as conn:
-        db_cursor = conn.cursor()
-
-        db_cursor.execute("""
-        UPDATE Posts
-            SET
-                user_id = ?,
-                category_id = ?,
-                title =?,
-                publication_date = ?,
-                image_url = ?,
-                content = ?,
-                approved = ?
-            WHERE id = ?
-        """, (new_post['user_id'], new_post['category_id'], new_post['title'], new_post['publication_date'],
-        new_post['image_url'], new_post['content'], new_post['approved'], id, ))
-
-        rows_affected = db_cursor.rowcount
-
-    if rows_affected == 0:
-        return False
-    else: 
-        return True
-
-def create_post(new_post):
-    with sqlite3.connect("./rare.db") as conn:
-        db_cursor = conn.cursor()
-
-        db_cursor.execute("""
-        INSERT INTO Posts
-            (user_id, category_id, title, publication_date, image_url, content, approved)
-        VALUES
-            (?, ?, ?, ?, ?, ?, ?);
-        """, (new_post['user_id'], new_post['category_id'], new_post['title'], new_post['publication_date'],
-        new_post['image_url'], new_post['content'], new_post['approved'], ))
-
-        id = db_cursor.lastrowid
-
-        new_post['id'] = id
-
-        for tag_id in new_post['tags']:
-            db_cursor.execute("""
-            INSERT INTO PostTags
-                (post_id, tag_id)
-            VALUES (?,?)
-            """, (new_post['id'], tag_id, ))
-
-    return json.dumps(new_post)
-
-def delete_post(id):
-    with sqlite3.connect("./rare.db") as conn:
-        db_cursor = conn.cursor()
-
-        db_cursor.execute("""
-        DELETE FROM Posts
-        WHERE id = ?
-        """, (id, ))
-
-def get_all_posts():
-    with sqlite3.connect("./rare.db") as conn:
-
-        conn.row_factory = sqlite3.Row
-        db_cursor = conn.cursor()
-
-        db_cursor.execute("""
-        SELECT
-            p.id,
-            p.user_id,
-            p.category_id,
-            p.title,
-            p.publication_date,
-            p.image_url,
-            p.content,
-            p.approved
-        FROM Posts p
-        """)
-
-        posts = []
-
-        dataset = db_cursor.fetchall()
-
-        for row in dataset:
-                post = POST(row['id'], row['user_id'], row['category_id'], row['title'], row['publication_date'], row['image_url'],row['content'], row['approved'])
-
-                db_cursor.execute("""
-                SELECT
-                    t.id,
-                    t.label
-                FROM Tags t
-                JOIN PostTags pt
-                    on t.id = pt.tag_id
-                JOIN Posts p on pt.post_id = p.id
-                WHERE p.id = ?
-                """, (post.id, ))
-
-                tag_rows = db_cursor.fetchall()
-
-                for tag_row in tag_rows:
-                    tag = {
-                        'id': tag_row['id'],
-                        'label': tag_row['label']
-                    }
-                    post.tags.append(tag)
-
-
-                posts.append(post.__dict__)
-
-        return json.dumps(posts)
-
-
-def get_single_post(id):
-    with sqlite3.connect("./rare.db") as conn:
-        conn.row_factory = sqlite3.Row
-        db_cursor = conn.cursor()
-
-        db_cursor.execute("""
-        SELECT
-            p.id,
-            p.user_id,
-            p.category_id,
-            p.title,
-            p.publication_date,
-            p.image_url,
-            p.content,
-            p.approved
-        FROM Posts p
-        WHERE p.id = ?
-        """, (id, ))
-
-        data = db_cursor.fetchone()
-
-        post = POST(data['id'], data['user_id'], data['category_id'], data['title'], data['publication_date'], data['image_url'], data['content'], data['approved'])
-
-        db_cursor.execute("""
-        SELECT
-            t.id,
-            t.label
-        FROM Tags t
-        JOIN PostTags pt
-            on t.id = pt.tag_id
-        JOIN Posts p on pt.post_id = p.id
-        WHERE p.id = ?
-        """, (post.id, ))
-
-        tag_rows = db_cursor.fetchall()
-
-        for tag_row in tag_rows:
-            tag = {
-                'id': tag_row['id'],
-                'label': tag_row['label']
-                }
-            post.tags.append(tag)
-
-    return json.dumps(post.__dict__)
 

--- a/rare.sql
+++ b/rare.sql
@@ -114,7 +114,9 @@ INSERT INTO `Comments` VALUES (null, 2, 1, 'Git Gud');
 
 INSERT INTO `Reactions` VALUES (null, 'Fire', 'https://i.pinimg.com/originals/e9/3a/6e/e93a6e90e2f5d302cba9cc870f2fbe42.png');
 
-INSERT INTO `PostsReactions` VALUES (null, 1, 1, 2);
+INSERT INTO `PostReactions` VALUES (null, 1, 4, 2);
+INSERT INTO `PostReactions` VALUES (null, 2, 3, 2);
+INSERT INTO `PostReactions` VALUES (null, 3, 1, 3);
 
 INSERT INTO `Tags` VALUES (null, 'Crafting');
 

--- a/reactions/__init__.py
+++ b/reactions/__init__.py
@@ -1,1 +1,1 @@
-from .request import get_all_reactions, create_reaction
+from .request import get_all_reactions, create_reaction, get_all_post_reactions, add_post_reaction

--- a/reactions/request.py
+++ b/reactions/request.py
@@ -1,6 +1,6 @@
 import sqlite3
 import json
-from models import REACTION
+from models import REACTION, PostReaction
 
 def get_all_reactions():
     with sqlite3.connect("./rare.db") as conn:
@@ -41,3 +41,49 @@ def create_reaction(new_reaction):
         new_reaction['id'] = id
 
     return json.dumps(new_reaction)
+
+
+def get_all_post_reactions():
+    """Gets all post reactions. Mainly for testing on this app"""
+    with sqlite3.connect("./rare.db") as conn:
+
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        SELECT
+            pr.id,
+            pr.user_id,
+            pr.reaction_id,
+            pr.post_id
+        FROM PostReactions pr
+        """)
+
+        postreactions = []
+
+        dataset = db_cursor.fetchall()
+
+        for row in dataset:
+
+            postreaction = PostReaction(row['id'],row['user_id'], row['reaction_id'], row['post_id'])
+
+            postreactions.append(postreaction.__dict__)
+
+    return json.dumps(postreactions)
+
+def add_post_reaction(postreaction):
+    with sqlite3.connect("./rare.db") as conn:
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        INSERT INTO PostReactions
+            (user_id, reaction_id, post_id)
+        VALUES
+            (?, ?, ?)
+        """, (postreaction['user_id'], postreaction['reaction_id'],postreaction['post_id']))
+
+        id = db_cursor.lastrowid
+
+        postreaction['id'] = id
+
+    return json.dumps(postreaction)

--- a/request_handler.py
+++ b/request_handler.py
@@ -1,4 +1,5 @@
 
+from reactions.request import get_all_post_reactions, add_post_reaction
 from tags import create_tag, delete_tag, get_all_tags, get_tags_by_post, get_tags_by_user, get_all_posttags, create_posttag, delete_posttag, update_tag
 from comments import get_comments_by_user
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -7,7 +8,7 @@ from users import get_all_users, get_single_user, create_user, delete_user, upda
 from posts import get_posts_by_category, update_post, create_post, delete_post, get_posts_by_subscription, get_single_post, get_all_posts, get_posts_by_user, get_posts_by_tag
 from comments import get_comments_by_post, get_comments_by_user, create_comment, update_comment, delete_comment, get_all_comments
 from categories import get_all_categories, create_category
-from reactions import get_all_reactions, create_reaction
+from reactions import get_all_reactions, create_reaction, get_all_post_reactions
 
 #Need to import all the functions to create, edit, delete, etc.
 
@@ -96,6 +97,9 @@ class HandleRequests(BaseHTTPRequestHandler):
             elif resource == "posttags":
                 response = get_all_posttags()
 
+            elif resource == "postreactions":
+                response = get_all_post_reactions()
+
             else:
                 response = []
         
@@ -156,6 +160,8 @@ class HandleRequests(BaseHTTPRequestHandler):
             response = create_category(post_body)
         elif resource == "reactions":
             response = create_reaction(post_body)
+        elif resource == "postreactions":
+            response = add_post_reaction(post_body)
         elif resource == "tags":
             response = create_tag(post_body)
         elif resource == "posttags":


### PR DESCRIPTION
User should be able to get all posts and get individual posts with the reactions included as an array. The user should also be able to add an existing reaction to a post (via postman) and that reaction should show up when the post is called up. Note that the user cannot add reactions directly to the post when it is created as those reactions should be coming from other users. 

***Steps to TEST

Pull this branch into a local test branch.

Run a local python server.

Double check to see that you have some entries in your postreactions table. Check especially that the table is titled postreactions and not postsreactions because this was not correct in the original code we got for our SQL. 

In Postman use a GET call with the URL: http://localhost:8088/posts and verify you get a list of posts with the proper reaction ids, labels, and image_urls embedded.

In Postman use a GET call with the URL: http://localhost:8088/posts/##, where the ## in the url corresponds to the id of the post that is returned.  Make sure all the individual post is returned with and that all the reactions are included with the returned information. 

In Postman use a GET call with the URL: http://localhost:8088/posttags and verify you get a list of relationships with a user_id, reaction_id, and a post_id.

In Postman, use a post call to the URL: http://localhost:8088/posttags with a user_id, reaction_id, and a post_id. Make sure that you have actual user ids, reaction ids, and post ids from your database. Make sure the new postreaction entry is successfully created.

In Postman use a GET call with the URL: http://localhost:8088/posts/##, where the ## corresponds to the post_id from the new postreaction entry above. Confirm that the post includes the reaction id, label, and url embedded. 
